### PR TITLE
Ability to specify Availability Zone

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,21 +197,33 @@ You can see that the YAML file has been created::
 You can run ``ho probe yaml`` anytime to check your configuration file, and
 especially after any manual modifications.
 
-Region
-------
+Region and Availability Zone
+----------------------------
 
 The next step is to configure the AWS Region. The default is ``eu-west-1``,
 i.e. "EU (Ireland)". If you want to use a different region, edit the YAML file
 (``aws.yaml`` in current directory) and edit the following line::
 
-    region: eu-west-1
+    region:
+      availability_zone:
+      region_str: eu-west-1
+
+If you don't care about the availability zone, just leave it unset. AWS will
+assign one.
+
+If you want to set an availability zone, you must do so before subnets are
+created, since subnets exist within an availability zone. Once subnets are
+created the availability zone cannot be changed (or, more accurately, it *can*
+be changed but ``ho install delegates`` will then fail because of the
+availability zone mismatch).
 
 Next, verify that you can connect to that region by running the command::
 
     (virtualenv)$ ho probe region
-    2016-03-30 21:54:34,545 INFO Loaded yaml tree from './aws.yaml'
-    2016-03-30 21:54:34,545 INFO Testing connectivity to AWS Region 'eu-west-1'
-    2016-03-30 23:02:52,146 INFO Detected 1 VPCs
+    2016-10-18 13:51:58,156 INFO Loaded yaml tree from './aws.yaml'
+    2016-10-18 13:51:58,156 INFO Testing connectivity to AWS Region {'region_str': 'us-east-1', 'availability_zone': None}
+    2016-10-18 13:51:58,404 INFO Detected 5 VPCs
+    2016-10-18 13:51:58,404 INFO Availability zone not set in YAML
 
 Virtual Private Cloud
 =====================

--- a/handson/cluster_options.py
+++ b/handson/cluster_options.py
@@ -46,7 +46,7 @@ class ClusterOptions(object):
         assert (
                 max_delegates is not None and
                 max_delegates > 0 and
-                max_delegates <= 50
+                max_delegates <= 100
         ), "Bad delegates stanza in YAML: {!r}".format(max_delegates)
         assert dl[-1] <= max_delegates, (
             ("Delegate list exceeds {!r} (maximum number of " +

--- a/handson/delegate.py
+++ b/handson/delegate.py
@@ -150,6 +150,7 @@ class Delegate(Region):
             "subnet_id": self._delegate['subnet_obj'].id,
             "instance_type": rd['type'],
             "private_ip_address": private_ip,
+            "placement": self.availability_zone()
         }
         # conditional kwargs
         if rd['user-data']:

--- a/handson/myyaml.py
+++ b/handson/myyaml.py
@@ -43,7 +43,10 @@ tree_stanzas = {
     'keyname': {'default': os.getlogin(), 'type': str},
     'keypairs': {'default': {}, 'type': dict},
     'nametag': {'default': 'handson', 'type': str},
-    'region': {'default': 'eu-west-1', 'type': str},
+    'region': {'default': {
+        'region_str': 'eu-west-1',
+        'availability_zone': None
+    }, 'type': dict},
     'role-definitions': {'default': {
         'admin': {'last-octet': 10},
         'defaults': {

--- a/handson/parsers.py
+++ b/handson/parsers.py
@@ -75,14 +75,14 @@ def expand_delegate_list(raw_input):
         if len(ti) == 2:
             if (
                     ti[1] > ti[0] and
-                    (ti[1] - ti[0]) < 50
+                    (ti[1] - ti[0]) < 100
             ):
                 intermediate_list.extend(range(ti[0], ti[1]+1))
                 continue
         assert 1 == 0, "Illegal delegate list {!r}".format(ti)
     final_list = list(sorted(set(intermediate_list), key=int))
     assert final_list[0] > 0, "detected too-low delegate (min. 1)"
-    assert final_list[-1] <= 50, "detected too-high delegate (max. 50)"
+    assert final_list[-1] <= 100, "detected too-high delegate (max. 100)"
     return final_list
 
 

--- a/handson/probe.py
+++ b/handson/probe.py
@@ -313,9 +313,21 @@ class ProbeRegion(InitArgs):
     def run(self):
         log.info("Testing connectivity to AWS Region {!r}"
                  .format(self.region))
-        vpc_conn = Region(self.args).vpc()
+        r = Region(self.args)
+        vpc_conn = r.vpc()
         vpc_count = len(vpc_conn.get_all_vpcs())
         log.info("Detected {!r} VPCs".format(vpc_count))
+        az = r.availability_zone()
+        if az:
+             log.info("Availability zone explicitly set to {}"
+                      .format(az))
+             ec2 = r.ec2()
+             if ec2.get_all_zones(zones=[az]):
+                 log.info("Availability zone is OK")
+             else:
+                 log.info("Availability zone is NOT OK!!!")
+        else:
+             log.info("Availability zone not set in YAML")
 
 
 class ProbeSubnets(InitArgs):

--- a/handson/region.py
+++ b/handson/region.py
@@ -67,11 +67,9 @@ class Region(object):
             return self._region['availability_zone']
         self._region['availability_zone'] = stanza('region')['availability_zone']
         if self._region['availability_zone']:
-            log.info("Availability zone is {}"
+            log.debug("Availability zone is {}"
                 .format(self._region['availability_zone'])
             )
-        else:
-            log.info("Availability zone not specified")
         return self._region['availability_zone']
 
     def ec2(self):

--- a/handson/region.py
+++ b/handson/region.py
@@ -45,7 +45,8 @@ class Region(object):
         self._region = {
             'ec2_conn': None,
             'region_str': None,
-            'vpc_conn': None
+            'vpc_conn': None,
+            'availability_zone': None
         }
 
     def region(self):

--- a/handson/region.py
+++ b/handson/region.py
@@ -55,9 +55,24 @@ class Region(object):
         """
         if self._region['region_str']:
             return self._region['region_str']
-        self._region['region_str'] = stanza('region')
+        self._region['region_str'] = stanza('region')['region_str']
         log.debug("Region is {}".format(self._region['region_str']))
         return self._region['region_str']
+
+    def availability_zone(self):
+        """
+            gets availability_zone from yaml, default to None
+        """
+        if self._region['availability_zone']:
+            return self._region['availability_zone']
+        self._region['availability_zone'] = stanza('region')['availability_zone']
+        if self._region['availability_zone']:
+            log.info("Availability zone is {}"
+                .format(self._region['availability_zone'])
+            )
+        else:
+            log.info("Availability zone not specified")
+        return self._region['availability_zone']
 
     def ec2(self):
         """

--- a/handson/subnet.py
+++ b/handson/subnet.py
@@ -58,6 +58,7 @@ class Subnet(VPC):
             return self._subnet['s_obj']
         s_stanza = stanza('subnets')
         log.debug("Subnet stanza {!r}".format(s_stanza))
+        az = self.availability_zone()
         vpc = self.vpc()
         vpc_obj = self.vpc_obj(create=False, quiet=True)
         delegate = self._subnet['delegate']
@@ -75,7 +76,8 @@ class Subnet(VPC):
                     s_obj = vpc.create_subnet(
                         vpc_obj.id,
                         cidr_block,
-                        dry_run=dry_run
+                        dry_run=dry_run,
+                        availability_zone=az
                     )
                     log.info(
                         "Created subnet {} ({})".format(


### PR DESCRIPTION
This is limited, though, because the AZ must be set before subnets are installed.

Fixes: #26