### PR TITLE
DeepSea ready cluster in AWS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1028,3 +1028,40 @@ Windows change administrator password via user-data script
 
 <script>net user Administrator GieGh7ie</script>
 
+
+Deploying with DeepSea
+===================
+
+Single delegate
+-------------------
+
+It is now possible to deploy a single Delegate Cluster in AWS using DeepSea
+instead of ceph-deploy.
+
+The user-data scripts already generate a `policy.cfg` example file assuming
+the existence of a master node with address 10.0.0.1, 2 mon nodes with
+addresses 10.0.1.1[123], and 4 storage nodes, with a single 20GB disk each,
+with the addresses 10.0.1.1[4567].
+
+After installing the delegate cluster in AWS, login into the Master node,
+and run the following commands as root::
+
+	salt-run state.orch ceph.stage.0
+	salt-run state.orch ceph.stage.1
+	salt-run state.orch ceph.stage.2
+	salt-run state.orch ceph.stage.3
+
+In the end of stage 3, you should have a fully deployed Ceph cluster. Check
+its status using the command `ceph -s`.
+
+Multiple delegates
+-----------------------
+
+It is also feasible to deploy multiple Delegate Clusters using DeepSea. Doing
+this would require running a salt-master instance for DeepSea for each
+Delegate, in addition to the ceph-auto-aws Salt Master node.
+
+The VM where the Delegate's salt-master instance runs would need to have two
+salt-minion instances: one pointing to the Delegate's salt-master instance and
+one pointing to the ceph-auto-aws Salt Master.
+

--- a/bootstrap
+++ b/bootstrap
@@ -6,7 +6,7 @@ fi
 set -ex
 rm -rf virtualenv .tox
 #virtualenv -p python3.4 virtualenv
-virtualenv virtualenv
+virtualenv -p python2.7 virtualenv
 source ./virtualenv/bin/activate
 pip install --upgrade pip 
 pip install --upgrade setuptools

--- a/deepsea/user-data-master
+++ b/deepsea/user-data-master
@@ -1,0 +1,115 @@
+#!/bin/bash -x
+#
+# user-data-master
+#
+# Launch script for Salt Master
+
+# update packages
+# wait for background zyppers to finish
+while sleep 5 ; do
+    zypper -n update
+    if [[ $? = 0 ]] ; then
+        break
+    fi
+done
+
+#set up resolv.conf
+echo "search @@REGION@@.compute.internal" >> /etc/resolv.conf
+
+# set up ntpd
+cat <<EOF >/etc/ntp.conf
+restrict -4 default notrap nomodify nopeer noquery
+restrict -6 default notrap nomodify nopeer noquery
+restrict 127.0.0.1
+restrict ::1
+restrict 10.0.0.0 mask 255.255.0.0
+driftfile /var/lib/ntp/drift/ntp.drift # path for drift file
+logfile   /var/log/ntp
+keys /etc/ntp.keys
+trustedkey 1
+requestkey 1
+controlkey 1
+server 0.amazon.pool.ntp.org iburst
+server 1.amazon.pool.ntp.org iburst
+server 2.amazon.pool.ntp.org iburst
+server 3.amazon.pool.ntp.org iburst
+EOF
+systemctl enable ntpd.service
+systemctl restart ntpd.service
+
+# set up salt master
+zypper -n install salt-master
+systemctl enable salt-master.service
+systemctl restart salt-master.service
+
+# salt minion
+zypper -n install salt-minion # creates /etc/salt/minion.d directory
+MINION_CONF=/etc/salt/minion.d/ceph.conf
+cat <<EOF > $MINION_CONF
+master: @@MASTER_IP@@
+grains:
+  delegate: @@DELEGATE@@
+  role: @@ROLE@@
+  node_no: @@NODE_NO@@
+EOF
+chown root:root $MINION_CONF
+chmod 0644 $MINION_CONF
+systemctl enable salt-minion.service
+systemctl start salt-minion.service
+
+# install git
+SUSEConnect -p sle-sdk/12.2/x86_64
+zypper --gpg-auto-import-keys ref
+zypper -n install --no-recommends git
+
+# generate SSH key
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+ssh-keygen -b 1024 -t rsa -q -N "" -f /root/.ssh/id_rsa
+
+# set motd
+cat <<EOF >/etc/motd
+This is the Salt Master.
+
+Have a lot of fun...
+EOF
+
+# clone salt recipes
+cd /srv
+git clone https://github.com/smithfarm/susecon-salt-master salt
+
+# inject SSH key
+cp /root/.ssh/id_rsa* /srv/salt
+chmod 644 /srv/salt/id_rsa*
+
+# install ttyrec
+zypper ar http://download.opensuse.org/repositories/utilities/SLE-12-SP1 utilities
+zypper --gpg-auto-import-keys ref
+zypper -n install ttyrec
+
+# wait for other instances to initialize
+sleep 30
+
+# install deepsea
+salt-key -Ay
+zypper -n install deepsea
+mkdir -p /srv/pillar/ceph/proposals
+
+cat <<EOF > /srv/pillar/ceph/proposals/policy.cfg
+# Cluster assignment
+cluster-ceph/cluster/*.sls
+# Hardware Profile
+1Disk20GB-1/cluster/*.sls
+1Disk20GB-1/stack/default/ceph/minions/*yml
+# Common configuration
+config/stack/default/global.yml
+config/stack/default/ceph/cluster.yml
+# Role assignment
+role-master/cluster/ip-10-0-0-10*.sls
+role-admin/cluster/ip-10-0-0-10*.sls
+role-admin/cluster/ip-10-0-1-1[123]*.sls
+role-mon/cluster/ip-10-0-1-1[123]*.sls
+role-mon/stack/default/ceph/minions/ip-10-0-1-1[123]*.yml
+EOF
+
+chown -R salt:salt /srv/*

--- a/deepsea/user-data-minions
+++ b/deepsea/user-data-minions
@@ -1,0 +1,32 @@
+#!/bin/bash -x
+#
+# user-data-minion
+#
+# Launch script for Salt Minion
+
+# update packages
+# wait for background zyppers to finish
+while sleep 5 ; do
+    zypper -n update
+    if [[ $? = 0 ]] ; then
+        break
+    fi
+done
+
+#set up resolv.conf
+echo "search @@REGION@@.compute.internal" >> /etc/resolv.conf
+
+# salt minion
+zypper -n install salt-minion # creates /etc/salt/minion.d directory
+MINION_CONF=/etc/salt/minion.d/ceph.conf
+cat <<EOF > $MINION_CONF
+master: @@MASTER_IP@@
+grains:
+  delegate: @@DELEGATE@@
+  role: @@ROLE@@
+  node_no: @@NODE_NO@@
+EOF
+chown root:root $MINION_CONF
+chmod 0644 $MINION_CONF
+systemctl enable salt-minion.service
+systemctl start salt-minion.service

--- a/handson/delegate.py
+++ b/handson/delegate.py
@@ -163,6 +163,7 @@ class Delegate(Region):
             u = template_token_subst(u, '@@DELEGATE@@', delegate)
             u = template_token_subst(u, '@@ROLE@@', role)
             u = template_token_subst(u, '@@NODE_NO@@', rd['node-no'])
+            u = template_token_subst(u, '@@REGION@@', self.region())
             our_kwargs['user_data'] = u
         reservation = ec2.run_instances(rd['ami-id'], **our_kwargs)
         i_obj = reservation.instances[0]


### PR DESCRIPTION
This PR adds user-data scripts to prepare the cluster to run DeepSea.

Using those scripts you can get a cluster in AWS ready for using DeepSea. The current scripts already generate a policy.cfg that will work for clusters with 3 mons 10.0.0.1[123], and 4 storage nodes 1.0.0.1[4567], and a master node 10.0.1.10.
