### PR TITLE
Renamed git package to git-core

### DIFF
--- a/susecon2017/user-data-root-master
+++ b/susecon2017/user-data-root-master
@@ -40,7 +40,7 @@ systemctl restart ntpd.service
 # install rpms
 zypper --gpg-auto-import-keys refresh
 zypper --non-interactive --no-gpg-checks install --no-recommends \
-    git \
+    git-core \
     salt-master
 
 # restart salt-master


### PR DESCRIPTION
git package in SLE12-SP3 is called "git-core".

The "git" package is only the srcpackage.

Signed-off-by: Kai Wagner <kwagner@suse.com>